### PR TITLE
Fix typo: "rate variable rate" => "variable rate"

### DIFF
--- a/_requests_for_research/inverse-draw.html
+++ b/_requests_for_research/inverse-draw.html
@@ -43,7 +43,7 @@ playing the role of the latent variables.
   is the case because each dimension of the observation gets assigned to one
   hidden state.  If this model were to successfully be made deep, we would get
   a hierarchy of representation, where each representation is operating at a
-  rate variable rate, which is trained to be as well-suited as possible for the
+  variable rate, which is trained to be as well-suited as possible for the
   current dataset.  
 </p>
 


### PR DESCRIPTION
This website is amazing and it's an honor to attempt to help out, even by copy-editing!